### PR TITLE
Check against X_IP_TRAIL header as well

### DIFF
--- a/hm-proxy-access.php
+++ b/hm-proxy-access.php
@@ -60,10 +60,12 @@ function is_proxied() {
 	}
 
 	// Is this proxied at all?
-	if ( empty( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
-		$ip = $_SERVER['REMOTE_ADDR'];
-	} else {
+	if ( ! empty( $_SERVER['HTTP_X_IP_TRAIL'] ) ) {
+		$ip = $_SERVER['HTTP_X_IP_TRAIL'];
+	} elseif ( ! empty( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
 		$ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
+	} else {
+		$ip = $_SERVER['REMOTE_ADDR'];
 	}
 
 	// There can be multiple IPs if there are multiple reverse proxies. E.g ELB -> Varnish -> The Server


### PR DESCRIPTION
Currently the code checks for REMOTE_ADDR, but sometimes behind Akamai edges the proxy IP is only contained in `X_IP_TRAIL`.